### PR TITLE
Buffering messages to increase UDP frame size performance.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .pioenvs
-platformio.sublime-project
+platformio.sublime*
+tests

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,7 +3,7 @@ to be made under the same license.
 ```
     /****************************************************************************
      *
-     * Copyright (c) 2015 Gus Grubba. All rights reserved.
+     * Copyright (c) 2015, 2016 Gus Grubba. All rights reserved.
      *
      * Redistribution and use in source and binary forms, with or without
      * modification, are permitted provided that the following conditions


### PR DESCRIPTION
Instead of sending messages out the UDP port every time a message arrives, I'm now buffering up to 5 messages (around 1,300 bytes) or 5 milliseconds, whichever comes first. Receiving data from the UART at 921600 baud, most of the time 2 or 3 messages get queued up before the timeout. For large data bursts, 5 messages in the queue are common. This helps performance as all messages will fit in one single UDP frame (as opposed to send one message per UDP frame).

With that said, QGC is showing a rather large amount of lost frames. My tests show that even after long periods of large data bursts at 921600 baud (PX4 -> UART -> 8266), not a single message was lost. That would indicate packets (or rather UDP frames) are being lost within QGC. I have yet to debug that.