### PR TITLE
Adding some delays to deal with UDP frame drops.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .pioenvs
 platformio.sublime*
+platformio.pro*
 tests

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -187,8 +187,8 @@ void loop() {
         delay(0);
         Vehicle.readMessage();
         delay(0);
-        check_reset();
-        delay(0);
+        //check_reset();
+        //delay(0);
     }
     updateServer.checkUpdates();
 }

--- a/src/mavesp8266.h
+++ b/src/mavesp8266.h
@@ -62,7 +62,7 @@ class MavESP8266GCS;
 //-- TODO: This needs to come from the build system
 #define MAVESP8266_VERSION_MAJOR    1
 #define MAVESP8266_VERSION_MINOR    0
-#define MAVESP8266_VERSION_BUILD    3
+#define MAVESP8266_VERSION_BUILD    4
 #define MAVESP8266_VERSION          ((MAVESP8266_VERSION_MAJOR << 24) & 0xFF00000) | ((MAVESP8266_VERSION_MINOR << 16) & 0x00FF0000) | (MAVESP8266_VERSION_BUILD & 0xFFFF)
 
 //-- Debug sent out to Serial1 (GPIO02), which is TX only (no RX).

--- a/src/mavesp8266_gcs.cpp
+++ b/src/mavesp8266_gcs.cpp
@@ -214,6 +214,7 @@ MavESP8266GCS::sendMessage(mavlink_message_t* message, int count) {
         _status.packets_sent++;
     }
     _udp.endPacket();
+    delay(0);
 }
 
 //---------------------------------------------------------------------------------
@@ -229,7 +230,7 @@ void
 MavESP8266GCS::_sendRadioStatus()
 {
     linkStatus* st = _forwardTo->getStatus();
-    //-- Build message    
+    //-- Build message
     mavlink_message_t msg;
     mavlink_msg_radio_status_pack(
         _forwardTo->systemID(),
@@ -255,7 +256,7 @@ MavESP8266GCS::_sendStatusMessage(uint8_t type, const char* text)
     if(!getWorld()->getParameters()->getDebugEnabled() && type == MAV_SEVERITY_DEBUG) {
         return;
     }
-    //-- Build message    
+    //-- Build message
     mavlink_message_t msg;
     mavlink_msg_statustext_pack(
         _forwardTo->systemID(),
@@ -371,6 +372,7 @@ MavESP8266GCS::_sendSingleUdpMessage(mavlink_message_t* msg)
     _udp.write((uint8_t*)(void*)buf, len);
     _udp.endPacket();
     _status.packets_sent++;
+    delay(0);
 }
 
 //---------------------------------------------------------------------------------
@@ -412,7 +414,6 @@ MavESP8266GCS::_handleCmdLong(mavlink_command_long_t* cmd)
         result
     );
     _sendSingleUdpMessage(&msg);
-    delay(0);
     if(reboot) {
         _wifiReboot();
     }

--- a/src/mavesp8266_vehicle.h
+++ b/src/mavesp8266_vehicle.h
@@ -41,7 +41,7 @@
 #include "mavesp8266.h"
 
 //-- UDP Outgoing Packet Queue
-#define UAS_QUEUE_SIZE          5
+#define UAS_QUEUE_SIZE          2
 #define UAS_QUEUE_TIMEOUT       5 // 5ms
 
 class MavESP8266Vehicle : public MavESP8266Bridge {


### PR DESCRIPTION
Decreasing the message buffer to 2 messages instead of 5. Apparently, the Espresif UDP stack has issues with outgoing frames larger than 512 bytes.
