### PR TITLE
Separate SSID and PWD for STA mode.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,25 +156,23 @@ void setup() {
     Parameters.begin();
 
     if(Parameters.getWifiMode() == WIFI_MODE_STA){
-      //-- Connect to an existing network
-      WiFi.mode(WIFI_STA);
-      WiFi.begin(Parameters.getWifiSsid(), Parameters.getWifiPassword());
-
-      //-- Wait a minute to connect
-      for(int i = 0; i < 120 && WiFi.status() != WL_CONNECTED; i++){
-          #ifdef ENABLE_DEBUG
-          Serial.print(".");
-          #endif
-          delay(500);
-      }
-
-      if(WiFi.status() == WL_CONNECTED){
-          localIP = WiFi.localIP();
-      } else {
-          //-- Fall back to AP mode if no connection could be established
-          WiFi.disconnect(true);
-          Parameters.setWifiMode(WIFI_MODE_AP);
-      }
+        //-- Connect to an existing network
+        WiFi.mode(WIFI_STA);
+        WiFi.begin(Parameters.getWifiStaSsid(), Parameters.getWifiStaPassword());
+        //-- Wait a minute to connect
+        for(int i = 0; i < 120 && WiFi.status() != WL_CONNECTED; i++) {
+            #ifdef ENABLE_DEBUG
+            Serial.print(".");
+            #endif
+            delay(500);
+        }
+        if(WiFi.status() == WL_CONNECTED) {
+            localIP = WiFi.localIP();
+        } else {
+            //-- Fall back to AP mode if no connection could be established
+            WiFi.disconnect(true);
+            Parameters.setWifiMode(WIFI_MODE_AP);
+        }
     }
 
     if(Parameters.getWifiMode() == WIFI_MODE_AP){
@@ -183,7 +181,6 @@ void setup() {
         WiFi.encryptionType(AUTH_WPA2_PSK);
         WiFi.softAP(Parameters.getWifiSsid(), Parameters.getWifiPassword(), Parameters.getWifiChannel());
         localIP = WiFi.softAPIP();
-        //-- I'm getting bogus IP from the DHCP server. Broadcasting for now.
         DEBUG_LOG("Waiting for DHCPD...\n");
         dhcp_status dstat = wifi_station_dhcpc_status();
         while (dstat != DHCP_STARTED) {
@@ -207,6 +204,7 @@ void setup() {
     DEBUG_LOG("Start WiFi Bridge\n");
     Parameters.setLocalIPAddress(localIP);
     IPAddress gcs_ip(localIP);
+    //-- I'm getting bogus IP from the DHCP server. Broadcasting for now.
     gcs_ip[3] = 255;
     GCS.begin((MavESP8266Bridge*)&Vehicle, gcs_ip);
     Vehicle.begin((MavESP8266Bridge*)&GCS);
@@ -221,7 +219,8 @@ void loop() {
         GCS.readMessage();
         delay(0);
         Vehicle.readMessage();
-        delay(0);
+        //-- TODO
+        //delay(0);
         //check_reset();
         //delay(0);
     }

--- a/src/mavesp8266.h
+++ b/src/mavesp8266.h
@@ -62,7 +62,7 @@ class MavESP8266GCS;
 //-- TODO: This needs to come from the build system
 #define MAVESP8266_VERSION_MAJOR    1
 #define MAVESP8266_VERSION_MINOR    0
-#define MAVESP8266_VERSION_BUILD    7
+#define MAVESP8266_VERSION_BUILD    8
 #define MAVESP8266_VERSION          ((MAVESP8266_VERSION_MAJOR << 24) & 0xFF00000) | ((MAVESP8266_VERSION_MINOR << 16) & 0x00FF0000) | (MAVESP8266_VERSION_BUILD & 0xFFFF)
 
 //-- Debug sent out to Serial1 (GPIO02), which is TX only (no RX).

--- a/src/mavesp8266_httpd.cpp
+++ b/src/mavesp8266_httpd.cpp
@@ -54,6 +54,8 @@ const char PROGMEM kAPPJSON[]    = "application/json";
 const char* kBAUD       = "baud";
 const char* kPWD        = "pwd";
 const char* kSSID       = "ssid";
+const char* kPWDSTA     = "pwdsta";
+const char* kSSIDSTA    = "ssidsta";
 const char* kCPORT      = "cport";
 const char* kHPORT      = "hport";
 const char* kCHANNEL    = "channel";
@@ -332,6 +334,14 @@ void handle_setParameters()
     if(webServer.hasArg(kSSID)) {
         ok = true;
         getWorld()->getParameters()->setWifiSsid(webServer.arg(kSSID).c_str());
+    }
+    if(webServer.hasArg(kPWDSTA)) {
+        ok = true;
+        getWorld()->getParameters()->setWifiStaPassword(webServer.arg(kPWDSTA).c_str());
+    }
+    if(webServer.hasArg(kSSIDSTA)) {
+        ok = true;
+        getWorld()->getParameters()->setWifiStaSsid(webServer.arg(kSSIDSTA).c_str());
     }
     if(webServer.hasArg(kCPORT)) {
         ok = true;

--- a/src/mavesp8266_parameters.cpp
+++ b/src/mavesp8266_parameters.cpp
@@ -57,28 +57,38 @@ uint16_t    _wifi_udp_cport;
 uint32_t    _wifi_ip_address;
 char        _wifi_ssid[16];
 char        _wifi_password[16];
+char        _wifi_ssidsta[16];
+char        _wifi_passwordsta[16];
 uint32_t    _uart_baud_rate;
 uint32_t    _flash_left;
 
 //-- Parameters
 //   No string support in parameters so we stash a char[16] into 4 uint32_t
  struct stMavEspParameters mavParameters[] = {
-     {"SW_VER",          &_sw_version,          MavESP8266Parameters::ID_FWVER,     sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  true },
-     {"DEBUG_ENABLED",   &_debug_enabled,       MavESP8266Parameters::ID_DEBUG,     sizeof(int8_t),     MAV_PARAM_TYPE_INT8,    false},
-     {"WIFI_MODE",       &_wifi_mode,           MavESP8266Parameters::ID_MODE,      sizeof(int8_t),     MAV_PARAM_TYPE_INT8,    false},
-     {"WIFI_CHANNEL",    &_wifi_channel,        MavESP8266Parameters::ID_CHANNEL,   sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
-     {"WIFI_UDP_HPORT",  &_wifi_udp_hport,      MavESP8266Parameters::ID_HPORT,     sizeof(uint16_t),   MAV_PARAM_TYPE_UINT16,  false},
-     {"WIFI_UDP_CPORT",  &_wifi_udp_cport,      MavESP8266Parameters::ID_CPORT,     sizeof(uint16_t),   MAV_PARAM_TYPE_UINT16,  false},
-     {"WIFI_IPADDRESS",  &_wifi_ip_address,     MavESP8266Parameters::ID_IPADDRESS, sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  true },
-     {"WIFI_SSID1",      &_wifi_ssid[0],        MavESP8266Parameters::ID_SSID1,     sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
-     {"WIFI_SSID2",      &_wifi_ssid[4],        MavESP8266Parameters::ID_SSID2,     sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
-     {"WIFI_SSID3",      &_wifi_ssid[8],        MavESP8266Parameters::ID_SSID3,     sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
-     {"WIFI_SSID4",      &_wifi_ssid[12],       MavESP8266Parameters::ID_SSID4,     sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
-     {"WIFI_PASSWORD1",  &_wifi_password[0],    MavESP8266Parameters::ID_PASS1,     sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
-     {"WIFI_PASSWORD2",  &_wifi_password[4],    MavESP8266Parameters::ID_PASS2,     sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
-     {"WIFI_PASSWORD3",  &_wifi_password[8],    MavESP8266Parameters::ID_PASS3,     sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
-     {"WIFI_PASSWORD4",  &_wifi_password[12],   MavESP8266Parameters::ID_PASS4,     sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
-     {"UART_BAUDRATE",   &_uart_baud_rate,      MavESP8266Parameters::ID_UART,      sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false}
+     {"SW_VER",             &_sw_version,           MavESP8266Parameters::ID_FWVER,     sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  true },
+     {"DEBUG_ENABLED",      &_debug_enabled,        MavESP8266Parameters::ID_DEBUG,     sizeof(int8_t),     MAV_PARAM_TYPE_INT8,    false},
+     {"WIFI_MODE",          &_wifi_mode,            MavESP8266Parameters::ID_MODE,      sizeof(int8_t),     MAV_PARAM_TYPE_INT8,    false},
+     {"WIFI_CHANNEL",       &_wifi_channel,         MavESP8266Parameters::ID_CHANNEL,   sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"WIFI_UDP_HPORT",     &_wifi_udp_hport,       MavESP8266Parameters::ID_HPORT,     sizeof(uint16_t),   MAV_PARAM_TYPE_UINT16,  false},
+     {"WIFI_UDP_CPORT",     &_wifi_udp_cport,       MavESP8266Parameters::ID_CPORT,     sizeof(uint16_t),   MAV_PARAM_TYPE_UINT16,  false},
+     {"WIFI_IPADDRESS",     &_wifi_ip_address,      MavESP8266Parameters::ID_IPADDRESS, sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  true },
+     {"WIFI_SSID1",         &_wifi_ssid[0],         MavESP8266Parameters::ID_SSID1,     sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"WIFI_SSID2",         &_wifi_ssid[4],         MavESP8266Parameters::ID_SSID2,     sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"WIFI_SSID3",         &_wifi_ssid[8],         MavESP8266Parameters::ID_SSID3,     sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"WIFI_SSID4",         &_wifi_ssid[12],        MavESP8266Parameters::ID_SSID4,     sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"WIFI_PASSWORD1",     &_wifi_password[0],     MavESP8266Parameters::ID_PASS1,     sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"WIFI_PASSWORD2",     &_wifi_password[4],     MavESP8266Parameters::ID_PASS2,     sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"WIFI_PASSWORD3",     &_wifi_password[8],     MavESP8266Parameters::ID_PASS3,     sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"WIFI_PASSWORD4",     &_wifi_password[12],    MavESP8266Parameters::ID_PASS4,     sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"WIFI_SSIDSTA1",      &_wifi_ssidsta[0],      MavESP8266Parameters::ID_SSIDSTA1,  sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"WIFI_SSIDSTA2",      &_wifi_ssidsta[4],      MavESP8266Parameters::ID_SSIDSTA2,  sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"WIFI_SSIDSTA3",      &_wifi_ssidsta[8],      MavESP8266Parameters::ID_SSIDSTA3,  sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"WIFI_SSIDSTA4",      &_wifi_ssidsta[12],     MavESP8266Parameters::ID_SSIDSTA4,  sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"WIFI_PWDSTA1",       &_wifi_passwordsta[0],  MavESP8266Parameters::ID_PASSSTA1,  sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"WIFI_PWDSTA2",       &_wifi_passwordsta[4],  MavESP8266Parameters::ID_PASSSTA2,  sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"WIFI_PWDSTA3",       &_wifi_passwordsta[8],  MavESP8266Parameters::ID_PASSSTA3,  sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"WIFI_PWDSTA4",       &_wifi_passwordsta[12], MavESP8266Parameters::ID_PASSSTA4,  sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false},
+     {"UART_BAUDRATE",      &_uart_baud_rate,       MavESP8266Parameters::ID_UART,      sizeof(uint32_t),   MAV_PARAM_TYPE_UINT32,  false}
 };
 
 //---------------------------------------------------------------------------------
@@ -129,6 +139,8 @@ uint16_t    MavESP8266Parameters::getWifiUdpHport   () { return _wifi_udp_hport;
 uint16_t    MavESP8266Parameters::getWifiUdpCport   () { return _wifi_udp_cport;    }
 char*       MavESP8266Parameters::getWifiSsid       () { return _wifi_ssid;         }
 char*       MavESP8266Parameters::getWifiPassword   () { return _wifi_password;     }
+char*       MavESP8266Parameters::getWifiStaSsid    () { return _wifi_ssidsta;      }
+char*       MavESP8266Parameters::getWifiStaPassword() { return _wifi_passwordsta;  }
 uint32_t    MavESP8266Parameters::getUartBaudRate   () { return _uart_baud_rate;    }
 
 //---------------------------------------------------------------------------------
@@ -143,8 +155,10 @@ MavESP8266Parameters::resetToDefaults()
     _wifi_udp_hport    = DEFAULT_UDP_HPORT;
     _wifi_udp_cport    = DEFAULT_UDP_CPORT;
     _uart_baud_rate    = DEFAULT_UART_SPEED;
-    strncpy(_wifi_ssid, kDEFAULT_SSID, sizeof(_wifi_ssid));
-    strncpy(_wifi_password, kDEFAULT_PASSWORD, sizeof(_wifi_password));
+    strncpy(_wifi_ssid,         kDEFAULT_SSID,      sizeof(_wifi_ssid));
+    strncpy(_wifi_password,     kDEFAULT_PASSWORD,  sizeof(_wifi_password));
+    strncpy(_wifi_ssidsta,      kDEFAULT_SSID,      sizeof(_wifi_ssid));
+    strncpy(_wifi_passwordsta,  kDEFAULT_PASSWORD,  sizeof(_wifi_password));
     _flash_left = ESP.getFreeSketchSpace();
 }
 
@@ -340,6 +354,20 @@ void
 MavESP8266Parameters::setWifiPassword(const char* pwd)
 {
     strncpy(_wifi_password, pwd, sizeof(_wifi_password));
+}
+
+//---------------------------------------------------------------------------------
+void
+MavESP8266Parameters::setWifiStaSsid(const char* ssid)
+{
+    strncpy(_wifi_ssidsta, ssid, sizeof(_wifi_ssidsta));
+}
+
+//---------------------------------------------------------------------------------
+void
+MavESP8266Parameters::setWifiStaPassword(const char* pwd)
+{
+    strncpy(_wifi_passwordsta, pwd, sizeof(_wifi_passwordsta));
 }
 
 //---------------------------------------------------------------------------------

--- a/src/mavesp8266_parameters.h
+++ b/src/mavesp8266_parameters.h
@@ -77,6 +77,14 @@ public:
         ID_PASS2,
         ID_PASS3,
         ID_PASS4,
+        ID_SSIDSTA1,
+        ID_SSIDSTA2,
+        ID_SSIDSTA3,
+        ID_SSIDSTA4,
+        ID_PASSSTA1,
+        ID_PASSSTA2,
+        ID_PASSSTA3,
+        ID_PASSSTA4,
         ID_UART,
         ID_COUNT
     };
@@ -95,6 +103,8 @@ public:
     uint16_t    getWifiUdpCport             ();
     char*       getWifiSsid                 ();
     char*       getWifiPassword             ();
+    char*       getWifiStaSsid              ();
+    char*       getWifiStaPassword          ();
     uint32_t    getUartBaudRate             ();
 
     void        setDebugEnabled             (int8_t enabled);
@@ -104,6 +114,8 @@ public:
     void        setWifiUdpCport             (uint16_t port);
     void        setWifiSsid                 (const char* ssid);
     void        setWifiPassword             (const char* pwd);
+    void        setWifiStaSsid              (const char* ssid);
+    void        setWifiStaPassword          (const char* pwd);
     void        setUartBaudRate             (uint32_t baud);
     void        setLocalIPAddress           (uint32_t ipAddress);
 


### PR DESCRIPTION
Adding a separate set of SSID/Password for Station Mode. That way, you can set the pair for station mode to match your existing, external AP but if the ESP module falls back to AP mode, it uses a separate set and doesn't collide with the external AP. Could I have made that sentence any longer?

Version bump to 1.0.8