### PR TITLE
Refactor component code, verify logging, and implement reset pin

### DIFF
--- a/HTTP.md
+++ b/HTTP.md
@@ -21,7 +21,7 @@ This will show the current comm link status.
 
 http://192.168.4.1/setparameters?key=value&key=value
 
-This will allow you to set any parameter to the specified value. Once set, the values are stored in non volatile memory (EEPROM) but will only take effect once you reboot it. Use this with caution as you may lock yourself out. For instance, if you change the AP password and don't remember later, currently there is no way to reset it other than reflashing the firmware. Also note that there is no validation done to the values entered. 
+This will allow you to set any parameter to the specified value. Once set, the values are stored in non volatile memory (EEPROM) but will only take effect once you reboot it. Use this with caution as you may lock yourself out. For instance, if you change the AP password and don't remember later, currently you must either trigger the reset pin (see README) or reflash the module in order to revert the parameters. Also note that there is no validation done to the values entered. 
 
 There are the supported parameters:
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The ```git clone --recursive``` above not only cloned the MavESP8266 repository 
 
 User level (as well as wiring) instructions can be found here: https://pixhawk.org/peripherals/8266
 
+* Resetting to Defaults: In case you change the parameters and get locked out of the module, all the parameters can be reset by bringing the GPIO02 pin low (Connect GPIO02 pin to GND pin). 
+
 ### MavLink Protocol
 
 The MavESP8266 handles its own set of parameters and commands. Look at the [PARAMETERS](PARAMETERS.md) page for more information.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 #include "mavesp8266_gcs.h"
 #include "mavesp8266_vehicle.h"
 #include "mavesp8266_httpd.h"
+#include "mavesp8266_component.h"
 
 #include <ESP8266mDNS.h>
 
@@ -79,6 +80,7 @@ private:
 
 //-- Singletons
 IPAddress               localIP;
+MavESP8266Component     Component;
 MavESP8266Parameters    Parameters;
 MavESP8266GCS           GCS;
 MavESP8266Vehicle       Vehicle;
@@ -91,6 +93,7 @@ MavESP8266Log           Logger;
 class MavESP8266WorldImp : public MavESP8266World {
 public:
     MavESP8266Parameters*   getParameters   () { return &Parameters;    }
+    MavESP8266Component*    getComponent    () { return &Component;     }
     MavESP8266Vehicle*      getVehicle      () { return &Vehicle;       }
     MavESP8266GCS*          getGCS          () { return &GCS;           }
     MavESP8266Log*          getLogger       () { return &Logger;        }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -129,15 +129,12 @@ void reset_interrupt(){
     Parameters.saveAllToEeprom();
     ESP.reset();
 }
-    }
-    */
-#endif
-}
 
 //---------------------------------------------------------------------------------
 //-- Set things up
 void setup() {
     delay(1000);
+    Parameters.begin();
 #ifdef ENABLE_DEBUG
     //   We only use it for non debug because GPIO02 is used as a serial
     //   pin (TX) when debugging.
@@ -151,7 +148,8 @@ void setup() {
 
     DEBUG_LOG("\nConfiguring access point...\n");
     DEBUG_LOG("Free Sketch Space: %u\n", ESP.getFreeSketchSpace());
-    Parameters.begin();
+
+    WiFi.disconnect(true);
 
     if(Parameters.getWifiMode() == WIFI_MODE_STA){
         //-- Connect to an existing network

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,14 +143,17 @@ void check_reset() {
 //-- Set things up
 void setup() {
     delay(1000);
-    Logger.begin(2048);
-#ifndef ENABLE_DEBUG
+#ifdef ENABLE_DEBUG
+    Serial1.begin(115200);
+#else
     //-- Initialized GPIO02 (Used for "Reset To Factory")
     //   We only use it for non debug because GPIO02 is used as a serial
     //   pin (TX) when debugging.
     pinMode(GPIO02, INPUT_PULLUP);
     reset_state = digitalRead(GPIO02);
 #endif
+    Logger.begin(2048);
+
     DEBUG_LOG("\nConfiguring access point...\n");
     DEBUG_LOG("Free Sketch Space: %u\n", ESP.getFreeSketchSpace());
     Parameters.begin();

--- a/src/mavesp8266.h
+++ b/src/mavesp8266.h
@@ -63,7 +63,7 @@ class MavESP8266GCS;
 //-- TODO: This needs to come from the build system
 #define MAVESP8266_VERSION_MAJOR    1
 #define MAVESP8266_VERSION_MINOR    0
-#define MAVESP8266_VERSION_BUILD    8
+#define MAVESP8266_VERSION_BUILD    9
 #define MAVESP8266_VERSION          ((MAVESP8266_VERSION_MAJOR << 24) & 0xFF00000) | ((MAVESP8266_VERSION_MINOR << 16) & 0x00FF0000) | (MAVESP8266_VERSION_BUILD & 0xFFFF)
 
 //-- Debug sent out to Serial1 (GPIO02), which is TX only (no RX).

--- a/src/mavesp8266.h
+++ b/src/mavesp8266.h
@@ -49,6 +49,7 @@
 }
 
 class MavESP8266Parameters;
+class MavESP8266Component;
 class MavESP8266Vehicle;
 class MavESP8266GCS;
 
@@ -133,6 +134,7 @@ class MavESP8266World {
 public:
     virtual ~MavESP8266World(){;}
     virtual MavESP8266Parameters*   getParameters   () = 0;
+    virtual MavESP8266Component*    getComponent    () = 0;
     virtual MavESP8266Vehicle*      getVehicle      () = 0;
     virtual MavESP8266GCS*          getGCS          () = 0;
     virtual MavESP8266Log*          getLogger       () = 0;

--- a/src/mavesp8266.h
+++ b/src/mavesp8266.h
@@ -117,8 +117,9 @@ public:
     MavESP8266Log   ();
     void            begin           (size_t bufferSize); // Allocate a buffer for the log
     size_t          log             (const char *format, ...); // Add to the log
-    String          getLog          (uint32_t position); // Get the log starting at a position
+    String          getLog          (uint32_t* pStart, uint32_t* pLen); // Get the log starting at a position
     uint32_t        getLogSize      (); // Number of bytes available at the current log position
+    uint32_t        getPosition     ();
 private:
     char*           _buffer; // Raw memory
     size_t          _buffer_size; // Size of the above memory

--- a/src/mavesp8266.h
+++ b/src/mavesp8266.h
@@ -63,7 +63,7 @@ class MavESP8266GCS;
 //-- TODO: This needs to come from the build system
 #define MAVESP8266_VERSION_MAJOR    1
 #define MAVESP8266_VERSION_MINOR    0
-#define MAVESP8266_VERSION_BUILD    9
+#define MAVESP8266_VERSION_BUILD    10
 #define MAVESP8266_VERSION          ((MAVESP8266_VERSION_MAJOR << 24) & 0xFF00000) | ((MAVESP8266_VERSION_MINOR << 16) & 0x00FF0000) | (MAVESP8266_VERSION_BUILD & 0xFFFF)
 
 //-- Debug sent out to Serial1 (GPIO02), which is TX only (no RX).

--- a/src/mavesp8266_component.cpp
+++ b/src/mavesp8266_component.cpp
@@ -48,10 +48,15 @@ MavESP8266Component::MavESP8266Component() {
 
 }
 
-// TODO: Instead of using sendUdpMessage, use sender->sendMessage
-
 bool
 MavESP8266Component::handleMessage(MavESP8266Bridge* sender, mavlink_message_t* message) {
+
+  //
+  //   TODO: These response messages need to be queued up and sent as part of the main loop and not all
+  //   at once from here.
+  //
+  //-----------------------------------------------
+
 
   //-- MAVLINK_MSG_ID_PARAM_SET
   if(message->msgid == MAVLINK_MSG_ID_PARAM_SET) {

--- a/src/mavesp8266_component.cpp
+++ b/src/mavesp8266_component.cpp
@@ -1,0 +1,293 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2015, 2016 Gus Grubba. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file mavesp8266_component.cpp
+ * ESP8266 Wifi AP, MavLink UART/UDP Bridge
+ *
+ * @author Gus Grubba <mavlink@grubba.com>
+ */
+
+#include "mavesp8266.h"
+#include "mavesp8266_component.h"
+#include "mavesp8266_parameters.h"
+#include "mavesp8266_vehicle.h"
+
+const char* kHASH_PARAM = "_HASH_CHECK";
+
+
+MavESP8266Component::MavESP8266Component() {
+
+
+}
+
+// TODO: Instead of using sendUdpMessage, use sender->sendMessage
+
+bool
+MavESP8266Component::handleMessage(MavESP8266Bridge* sender, mavlink_message_t* message) {
+
+  //-- MAVLINK_MSG_ID_PARAM_SET
+  if(message->msgid == MAVLINK_MSG_ID_PARAM_SET) {
+      mavlink_param_set_t param;
+      mavlink_msg_param_set_decode(message, &param);
+      DEBUG_LOG("MAVLINK_MSG_ID_PARAM_SET: %u %s\n", param.target_component, param.param_id);
+      if(param.target_component == MAV_COMP_ID_UDP_BRIDGE) {
+          _handleParamSet(sender, &param);
+          return true;
+      }
+  //-----------------------------------------------
+  //-- MAVLINK_MSG_ID_COMMAND_LONG
+  } else if(message->msgid == MAVLINK_MSG_ID_COMMAND_LONG) {
+      mavlink_command_long_t cmd;
+      mavlink_msg_command_long_decode(message, &cmd);
+      if(cmd.target_component == MAV_COMP_ID_ALL || cmd.target_component == MAV_COMP_ID_UDP_BRIDGE) {
+          _handleCmdLong(sender, &cmd, cmd.target_component);
+          //-- If it was directed to us, eat it and loop
+          if(cmd.target_component == MAV_COMP_ID_UDP_BRIDGE) {
+              return true;
+          }
+      }
+  //-----------------------------------------------
+  //-- MAVLINK_MSG_ID_PARAM_REQUEST_LIST
+  } else if(message->msgid == MAVLINK_MSG_ID_PARAM_REQUEST_LIST) {
+      mavlink_param_request_list_t param;
+      mavlink_msg_param_request_list_decode(message, &param);
+      DEBUG_LOG("MAVLINK_MSG_ID_PARAM_REQUEST_LIST: %u\n", param.target_component);
+      if(param.target_component == MAV_COMP_ID_ALL || param.target_component == MAV_COMP_ID_UDP_BRIDGE) {
+          _handleParamRequestList(sender);
+      }
+  //-----------------------------------------------
+  //-- MAVLINK_MSG_ID_PARAM_REQUEST_READ
+  } else if(message->msgid == MAVLINK_MSG_ID_PARAM_REQUEST_READ) {
+      mavlink_param_request_read_t param;
+      mavlink_msg_param_request_read_decode(message, &param);
+      //-- This component or all components?
+      if(param.target_component == MAV_COMP_ID_ALL || param.target_component == MAV_COMP_ID_UDP_BRIDGE) {
+          //-- If asking for hash, respond and pass through to the UAS
+          if(strncmp(param.param_id, kHASH_PARAM, MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN) == 0) {
+              _sendParameter(sender, kHASH_PARAM, getWorld()->getParameters()->paramHashCheck(), 0xFFFF);
+          } else {
+              _handleParamRequestRead(sender, &param);
+              //-- If this was addressed to me only eat message
+              if(param.target_component == MAV_COMP_ID_UDP_BRIDGE) {
+                  //-- Eat message (don't send it to FC)
+                  return true;
+              }
+          }
+      }
+  }
+
+  //-- Couldn't handle the message, pass on
+  return false;
+}
+
+
+
+
+
+//---------------------------------------------------------------------------------
+//-- Send Debug Message
+void
+MavESP8266Component::_sendStatusMessage(MavESP8266Bridge* sender, uint8_t type, const char* text)
+{
+    if(!getWorld()->getParameters()->getDebugEnabled() && type == MAV_SEVERITY_DEBUG) {
+        return;
+    }
+    //-- Build message
+    mavlink_message_t msg;
+    mavlink_msg_statustext_pack(
+        getWorld()->getVehicle()->systemID(),
+        MAV_COMP_ID_UDP_BRIDGE,
+        &msg,
+        type,
+        text
+    );
+    sender->sendMessage(&msg);
+}
+
+
+
+
+//---------------------------------------------------------------------------------
+//-- Set parameter
+void
+MavESP8266Component::_handleParamSet(MavESP8266Bridge* sender, mavlink_param_set_t* param)
+{
+    for(int i = 0; i < MavESP8266Parameters::ID_COUNT; i++) {
+        //-- Find parameter
+        if(strncmp(param->param_id, getWorld()->getParameters()->getAt(i)->id, strlen(getWorld()->getParameters()->getAt(i)->id)) == 0) {
+            //-- Skip Read Only
+            if(!getWorld()->getParameters()->getAt(i)->readOnly) {
+                //-- Set new value
+                memcpy(getWorld()->getParameters()->getAt(i)->value, &param->param_value, getWorld()->getParameters()->getAt(i)->length);
+            }
+            //-- "Ack" it
+            _sendParameter(sender, getWorld()->getParameters()->getAt(i)->index);
+            return;
+        }
+    }
+}
+
+//---------------------------------------------------------------------------------
+//-- Handle Parameter Request List
+void
+MavESP8266Component::_handleParamRequestList(MavESP8266Bridge* sender)
+{
+    for(int i = 0; i < MavESP8266Parameters::ID_COUNT; i++) {
+        _sendParameter(sender, getWorld()->getParameters()->getAt(i)->index);
+        delay(0);
+    }
+}
+
+//---------------------------------------------------------------------------------
+//-- Handle Parameter Request Read
+void
+MavESP8266Component::_handleParamRequestRead(MavESP8266Bridge* sender, mavlink_param_request_read_t* param)
+{
+    for(int i = 0; i < MavESP8266Parameters::ID_COUNT; i++) {
+        //-- Find parameter
+        if(param->param_index == getWorld()->getParameters()->getAt(i)->index || strncmp(param->param_id, getWorld()->getParameters()->getAt(i)->id, strlen(getWorld()->getParameters()->getAt(i)->id)) == 0) {
+            _sendParameter(sender, getWorld()->getParameters()->getAt(i)->index);
+            return;
+        }
+    }
+}
+
+//---------------------------------------------------------------------------------
+//-- Send Parameter (Index Based)
+void
+MavESP8266Component::_sendParameter(MavESP8266Bridge* sender, uint16_t index)
+{
+    //-- Build message
+    mavlink_param_value_t msg;
+    msg.param_count = MavESP8266Parameters::ID_COUNT;
+    msg.param_index = index;
+    strncpy(msg.param_id, getWorld()->getParameters()->getAt(index)->id, MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN);
+    uint32_t val = 0;
+    memcpy(&val, getWorld()->getParameters()->getAt(index)->value, getWorld()->getParameters()->getAt(index)->length);
+    memcpy(&msg.param_value, &val, sizeof(uint32_t));
+    msg.param_type = getWorld()->getParameters()->getAt(index)->type;
+    mavlink_message_t mmsg;
+    mavlink_msg_param_value_encode(
+        getWorld()->getVehicle()->systemID(),
+        MAV_COMP_ID_UDP_BRIDGE,
+        &mmsg,
+        &msg
+    );
+
+    sender->sendMessage(&mmsg);
+}
+
+//---------------------------------------------------------------------------------
+//-- Send Parameter (Raw)
+void
+MavESP8266Component::_sendParameter(MavESP8266Bridge* sender, const char* id, uint32_t value, uint16_t index)
+{
+    //-- Build message
+    mavlink_param_value_t msg;
+    msg.param_count = MavESP8266Parameters::ID_COUNT;
+    msg.param_index = index;
+    strncpy(msg.param_id, id, MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN);
+    memcpy(&msg.param_value, &value, sizeof(uint32_t));
+    msg.param_type = MAV_PARAM_TYPE_UINT32;
+    mavlink_message_t mmsg;
+    mavlink_msg_param_value_encode(
+        getWorld()->getVehicle()->systemID(),
+        MAV_COMP_ID_UDP_BRIDGE,
+        &mmsg,
+        &msg
+    );
+    sender->sendMessage(&mmsg);
+}
+
+
+
+
+
+
+
+
+//---------------------------------------------------------------------------------
+//-- Handle Commands
+void
+MavESP8266Component::_handleCmdLong(MavESP8266Bridge* sender, mavlink_command_long_t* cmd, uint8_t compID)
+{
+    bool reboot = false;
+    uint8_t result = MAV_RESULT_UNSUPPORTED;
+    if(cmd->command == MAV_CMD_PREFLIGHT_STORAGE) {
+        //-- Read from EEPROM
+        if((uint8_t)cmd->param1 == 0) {
+            result = MAV_RESULT_ACCEPTED;
+            getWorld()->getParameters()->loadAllFromEeprom();
+        //-- Write to EEPROM
+        } else if((uint8_t)cmd->param1 == 1) {
+            result = MAV_RESULT_ACCEPTED;
+            getWorld()->getParameters()->saveAllToEeprom();
+            delay(0);
+        //-- Restore defaults
+        } else if((uint8_t)cmd->param1 == 2) {
+            result = MAV_RESULT_ACCEPTED;
+            getWorld()->getParameters()->resetToDefaults();
+        }
+    } else if(cmd->command == MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN) {
+        //-- Reset "Companion Computer"
+        if((uint8_t)cmd->param2 == 1) {
+            result = MAV_RESULT_ACCEPTED;
+            reboot = true;
+        }
+    }
+    //-- Response
+    if(compID == MAV_COMP_ID_UDP_BRIDGE) {
+        mavlink_message_t msg;
+        mavlink_msg_command_ack_pack(
+            getWorld()->getVehicle()->systemID(),
+            //_forwardTo->systemID(),
+            MAV_COMP_ID_UDP_BRIDGE,
+            &msg,
+            cmd->command,
+            result
+        );
+        sender->sendMessage(&msg);
+    }
+    if(reboot) {
+        _wifiReboot(sender);
+    }
+}
+
+
+//---------------------------------------------------------------------------------
+//-- Reboot
+void
+MavESP8266Component::_wifiReboot(MavESP8266Bridge* sender)
+{
+    _sendStatusMessage(sender, MAV_SEVERITY_NOTICE, "Rebooting WiFi Bridge.");
+    delay(50);
+    ESP.reset();
+}

--- a/src/mavesp8266_component.h
+++ b/src/mavesp8266_component.h
@@ -29,39 +29,35 @@
  ****************************************************************************/
 
 /**
- * @file mavesp8266_gcs.h
+ * @file mavesp8266_component.h
  * ESP8266 Wifi AP, MavLink UART/UDP Bridge
  *
  * @author Gus Grubba <mavlink@grubba.com>
  */
 
-#ifndef MAVESP8266_GCS_H
-#define MAVESP8266_GCS_H
+#ifndef MAVESP8266_COMPONENT_H
+#define MAVESP8266_COMPONENT_H
 
 #include "mavesp8266.h"
 
-class MavESP8266GCS : public MavESP8266Bridge {
+class MavESP8266Component {
 public:
-    MavESP8266GCS();
+    MavESP8266Component();
 
-    void    begin                   (MavESP8266Bridge* forwardTo, IPAddress gcsIP);
-    void    readMessage             ();
-    void    sendMessage             (mavlink_message_t* message, int count);
-    void    sendMessage             (mavlink_message_t* message);
+    //- Returns true if the component consumed the message
+    bool handleMessage        (MavESP8266Bridge* sender, mavlink_message_t* message);
 
 private:
-    bool    _readMessage            ();
-    void    _sendRadioStatus        ();
+    void    _sendStatusMessage      (MavESP8266Bridge* sender, uint8_t type, const char* text);
+    void    _handleParamSet         (MavESP8266Bridge* sender, mavlink_param_set_t* param);
+    void    _handleParamRequestList (MavESP8266Bridge* sender);
+    void    _handleParamRequestRead (MavESP8266Bridge* sender, mavlink_param_request_read_t* param);
+    void    _sendParameter          (MavESP8266Bridge* sender, uint16_t index);
+    void    _sendParameter          (MavESP8266Bridge* sender, const char* id, uint32_t value, uint16_t index);
 
-    void    _sendSingleUdpMessage   (mavlink_message_t* msg);
-    void    _checkUdpErrors         (mavlink_message_t* msg);
+    void    _handleCmdLong          (MavESP8266Bridge* sender, mavlink_command_long_t* cmd, uint8_t compID);
 
-private:
-    WiFiUDP             _udp;
-    IPAddress           _ip;
-    uint16_t            _udp_port;
-    mavlink_message_t   _message;
-    unsigned long       _last_status_time;
+    void    _wifiReboot             (MavESP8266Bridge* sender);
 };
 
 #endif

--- a/src/mavesp8266_gcs.cpp
+++ b/src/mavesp8266_gcs.cpp
@@ -38,8 +38,7 @@
 #include "mavesp8266.h"
 #include "mavesp8266_gcs.h"
 #include "mavesp8266_parameters.h"
-
-const char* kHASH_PARAM = "_HASH_CHECK";
+#include "mavesp8266_component.h"
 
 //---------------------------------------------------------------------------------
 MavESP8266GCS::MavESP8266GCS()
@@ -123,70 +122,24 @@ MavESP8266GCS::_readMessage()
                             _last_heartbeat = millis();
                         _checkLinkErrors(&_message);
                     }
-                    //-- Check for message we might be interested
+
+
                     //
                     //   TODO: These response messages need to be queued up and sent as part of the main loop and not all
                     //   at once from here.
                     //
                     //-----------------------------------------------
-                    //-- MAVLINK_MSG_ID_PARAM_SET
-                    if(_message.msgid == MAVLINK_MSG_ID_PARAM_SET) {
-                        mavlink_param_set_t param;
-                        mavlink_msg_param_set_decode(&_message, &param);
-                        DEBUG_LOG("MAVLINK_MSG_ID_PARAM_SET: %u %s\n", param.target_component, param.param_id);
-                        if(param.target_component == MAV_COMP_ID_UDP_BRIDGE) {
-                            _handleParamSet(&param);
-                            //-- Eat message (don't send it to FC)
-                            memset(&_message, 0, sizeof(_message));
-                            msgReceived = false;
-                            continue;
-                        }
-                    //-----------------------------------------------
-                    //-- MAVLINK_MSG_ID_COMMAND_LONG
-                    } else if(_message.msgid == MAVLINK_MSG_ID_COMMAND_LONG) {
-                        mavlink_command_long_t cmd;
-                        mavlink_msg_command_long_decode(&_message, &cmd);
-                        if(cmd.target_component == MAV_COMP_ID_ALL || cmd.target_component == MAV_COMP_ID_UDP_BRIDGE) {
-                            _handleCmdLong(&cmd, cmd.target_component);
-                            //-- If it was directed to us, eat it and loop
-                            if(cmd.target_component == MAV_COMP_ID_UDP_BRIDGE) {
-                                //-- Eat message (don't send it to FC)
-                                memset(&_message, 0, sizeof(_message));
-                                msgReceived = false;
-                                continue;
-                            }
-                        }
-                    //-----------------------------------------------
-                    //-- MAVLINK_MSG_ID_PARAM_REQUEST_LIST
-                    } else if(_message.msgid == MAVLINK_MSG_ID_PARAM_REQUEST_LIST) {
-                        mavlink_param_request_list_t param;
-                        mavlink_msg_param_request_list_decode(&_message, &param);
-                        DEBUG_LOG("MAVLINK_MSG_ID_PARAM_REQUEST_LIST: %u\n", param.target_component);
-                        if(param.target_component == MAV_COMP_ID_ALL || param.target_component == MAV_COMP_ID_UDP_BRIDGE) {
-                            _handleParamRequestList();
-                        }
-                    //-----------------------------------------------
-                    //-- MAVLINK_MSG_ID_PARAM_REQUEST_READ
-                    } else if(_message.msgid == MAVLINK_MSG_ID_PARAM_REQUEST_READ) {
-                        mavlink_param_request_read_t param;
-                        mavlink_msg_param_request_read_decode(&_message, &param);
-                        //-- This component or all components?
-                        if(param.target_component == MAV_COMP_ID_ALL || param.target_component == MAV_COMP_ID_UDP_BRIDGE) {
-                            //-- If asking for hash, respond and pass through to the UAS
-                            if(strncmp(param.param_id, kHASH_PARAM, MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN) == 0) {
-                                _sendParameter(kHASH_PARAM, getWorld()->getParameters()->paramHashCheck(), 0xFFFF);
-                            } else {
-                                _handleParamRequestRead(&param);
-                                //-- If this was addressed to me only eat message
-                                if(param.target_component == MAV_COMP_ID_UDP_BRIDGE) {
-                                    //-- Eat message (don't send it to FC)
-                                    memset(&_message, 0, sizeof(_message));
-                                    msgReceived = false;
-                                    continue;
-                                }
-                            }
-                        }
+
+
+                    //-- Check for message we might be interested
+                    if(getWorld()->getComponent()->handleMessage(this, &_message)){
+                        //-- Eat message (don't send it to FC)
+                        memset(&_message, 0, sizeof(_message));
+                        msgReceived = false;
+                        continue;
                     }
+
+
                     //-- Got message, leave
                     break;
                 }
@@ -255,116 +208,6 @@ MavESP8266GCS::_sendRadioStatus()
     _status.radio_status_sent++;
 }
 
-//---------------------------------------------------------------------------------
-//-- Send Debug Message
-void
-MavESP8266GCS::_sendStatusMessage(uint8_t type, const char* text)
-{
-    if(!getWorld()->getParameters()->getDebugEnabled() && type == MAV_SEVERITY_DEBUG) {
-        return;
-    }
-    //-- Build message
-    mavlink_message_t msg;
-    mavlink_msg_statustext_pack(
-        _forwardTo->systemID(),
-        MAV_COMP_ID_UDP_BRIDGE,
-        &msg,
-        type,
-        text
-    );
-    _sendSingleUdpMessage(&msg);
-}
-
-//---------------------------------------------------------------------------------
-//-- Set parameter
-void
-MavESP8266GCS::_handleParamSet(mavlink_param_set_t* param)
-{
-    for(int i = 0; i < MavESP8266Parameters::ID_COUNT; i++) {
-        //-- Find parameter
-        if(strncmp(param->param_id, getWorld()->getParameters()->getAt(i)->id, strlen(getWorld()->getParameters()->getAt(i)->id)) == 0) {
-            //-- Skip Read Only
-            if(!getWorld()->getParameters()->getAt(i)->readOnly) {
-                //-- Set new value
-                memcpy(getWorld()->getParameters()->getAt(i)->value, &param->param_value, getWorld()->getParameters()->getAt(i)->length);
-            }
-            //-- "Ack" it
-            _sendParameter(getWorld()->getParameters()->getAt(i)->index);
-            return;
-        }
-    }
-}
-
-//---------------------------------------------------------------------------------
-//-- Handle Parameter Request List
-void
-MavESP8266GCS::_handleParamRequestList()
-{
-    for(int i = 0; i < MavESP8266Parameters::ID_COUNT; i++) {
-        _sendParameter(getWorld()->getParameters()->getAt(i)->index);
-        delay(0);
-    }
-}
-
-//---------------------------------------------------------------------------------
-//-- Handle Parameter Request Read
-void
-MavESP8266GCS::_handleParamRequestRead(mavlink_param_request_read_t* param)
-{
-    for(int i = 0; i < MavESP8266Parameters::ID_COUNT; i++) {
-        //-- Find parameter
-        if(param->param_index == getWorld()->getParameters()->getAt(i)->index || strncmp(param->param_id, getWorld()->getParameters()->getAt(i)->id, strlen(getWorld()->getParameters()->getAt(i)->id)) == 0) {
-            _sendParameter(getWorld()->getParameters()->getAt(i)->index);
-            return;
-        }
-    }
-}
-
-//---------------------------------------------------------------------------------
-//-- Send Parameter (Index Based)
-void
-MavESP8266GCS::_sendParameter(uint16_t index)
-{
-    //-- Build message
-    mavlink_param_value_t msg;
-    msg.param_count = MavESP8266Parameters::ID_COUNT;
-    msg.param_index = index;
-    strncpy(msg.param_id, getWorld()->getParameters()->getAt(index)->id, MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN);
-    uint32_t val = 0;
-    memcpy(&val, getWorld()->getParameters()->getAt(index)->value, getWorld()->getParameters()->getAt(index)->length);
-    memcpy(&msg.param_value, &val, sizeof(uint32_t));
-    msg.param_type = getWorld()->getParameters()->getAt(index)->type;
-    mavlink_message_t mmsg;
-    mavlink_msg_param_value_encode(
-        _forwardTo->systemID(),
-        MAV_COMP_ID_UDP_BRIDGE,
-        &mmsg,
-        &msg
-    );
-    _sendSingleUdpMessage(&mmsg);
-}
-
-//---------------------------------------------------------------------------------
-//-- Send Parameter (Raw)
-void
-MavESP8266GCS::_sendParameter(const char* id, uint32_t value, uint16_t index)
-{
-    //-- Build message
-    mavlink_param_value_t msg;
-    msg.param_count = MavESP8266Parameters::ID_COUNT;
-    msg.param_index = index;
-    strncpy(msg.param_id, id, MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN);
-    memcpy(&msg.param_value, &value, sizeof(uint32_t));
-    msg.param_type = MAV_PARAM_TYPE_UINT32;
-    mavlink_message_t mmsg;
-    mavlink_msg_param_value_encode(
-        _forwardTo->systemID(),
-        MAV_COMP_ID_UDP_BRIDGE,
-        &mmsg,
-        &msg
-    );
-    _sendSingleUdpMessage(&mmsg);
-}
 
 //---------------------------------------------------------------------------------
 //-- Send UDP Single Message
@@ -380,60 +223,4 @@ MavESP8266GCS::_sendSingleUdpMessage(mavlink_message_t* msg)
     _udp.endPacket();
     _status.packets_sent++;
     delay(0);
-}
-
-//---------------------------------------------------------------------------------
-//-- Handle Commands
-void
-MavESP8266GCS::_handleCmdLong(mavlink_command_long_t* cmd, uint8_t compID)
-{
-    bool reboot = false;
-    uint8_t result = MAV_RESULT_UNSUPPORTED;
-    if(cmd->command == MAV_CMD_PREFLIGHT_STORAGE) {
-        //-- Read from EEPROM
-        if((uint8_t)cmd->param1 == 0) {
-            result = MAV_RESULT_ACCEPTED;
-            getWorld()->getParameters()->loadAllFromEeprom();
-        //-- Write to EEPROM
-        } else if((uint8_t)cmd->param1 == 1) {
-            result = MAV_RESULT_ACCEPTED;
-            getWorld()->getParameters()->saveAllToEeprom();
-            delay(0);
-        //-- Restore defaults
-        } else if((uint8_t)cmd->param1 == 2) {
-            result = MAV_RESULT_ACCEPTED;
-            getWorld()->getParameters()->resetToDefaults();
-        }
-    } else if(cmd->command == MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN) {
-        //-- Reset "Companion Computer"
-        if((uint8_t)cmd->param2 == 1) {
-            result = MAV_RESULT_ACCEPTED;
-            reboot = true;
-        }
-    }
-    //-- Response
-    if(compID == MAV_COMP_ID_UDP_BRIDGE) {
-        mavlink_message_t msg;
-        mavlink_msg_command_ack_pack(
-            _forwardTo->systemID(),
-            MAV_COMP_ID_UDP_BRIDGE,
-            &msg,
-            cmd->command,
-            result
-        );
-        _sendSingleUdpMessage(&msg);
-    }
-    if(reboot) {
-        _wifiReboot();
-    }
-}
-
-//---------------------------------------------------------------------------------
-//-- Reboot
-void
-MavESP8266GCS::_wifiReboot()
-{
-    _sendStatusMessage(MAV_SEVERITY_NOTICE, "Rebooting WiFi Bridge.");
-    delay(50);
-    ESP.reset();
 }

--- a/src/mavesp8266_gcs.cpp
+++ b/src/mavesp8266_gcs.cpp
@@ -124,12 +124,6 @@ MavESP8266GCS::_readMessage()
                     }
 
 
-                    //
-                    //   TODO: These response messages need to be queued up and sent as part of the main loop and not all
-                    //   at once from here.
-                    //
-                    //-----------------------------------------------
-
 
                     //-- Check for message we might be interested
                     if(getWorld()->getComponent()->handleMessage(this, &_message)){

--- a/src/mavesp8266_httpd.cpp
+++ b/src/mavesp8266_httpd.cpp
@@ -237,13 +237,13 @@ void handle_getStatus()
 //---------------------------------------------------------------------------------
 void handle_getJLog()
 {
-    uint32_t position = 0;
+    uint32_t position = 0, len;
     if(webServer.hasArg(kPOSITION)) {
         position = webServer.arg(kPOSITION).toInt();
     }
-    String logText = getWorld()->getLogger()->getLog(position);
+    String logText = getWorld()->getLogger()->getLog(&position, &len);
     char jStart[128];
-    snprintf(jStart, 128, "{\"len\":%d, \"start\":%d, \"text\": \"", logText.length(), position);
+    snprintf(jStart, 128, "{\"len\":%d, \"start\":%d, \"text\": \"", len, position);
     String payLoad = jStart;
     payLoad += logText;
     payLoad += "\"}";
@@ -273,7 +273,7 @@ void handle_getJSysInfo()
         fid & 0xff, (fid & 0xff00) | ((fid >> 16) & 0xff),
         flash,
         ESP.getFreeHeap(),
-        getWorld()->getLogger()->getLogSize(),
+        getWorld()->getLogger()->getPosition(),
         paramCRC
     );
     webServer.send(200, "application/json", message);

--- a/src/mavesp8266_parameters.cpp
+++ b/src/mavesp8266_parameters.cpp
@@ -157,8 +157,8 @@ MavESP8266Parameters::resetToDefaults()
     _uart_baud_rate    = DEFAULT_UART_SPEED;
     strncpy(_wifi_ssid,         kDEFAULT_SSID,      sizeof(_wifi_ssid));
     strncpy(_wifi_password,     kDEFAULT_PASSWORD,  sizeof(_wifi_password));
-    strncpy(_wifi_ssidsta,      kDEFAULT_SSID,      sizeof(_wifi_ssid));
-    strncpy(_wifi_passwordsta,  kDEFAULT_PASSWORD,  sizeof(_wifi_password));
+    strncpy(_wifi_ssidsta,      kDEFAULT_SSID,      sizeof(_wifi_ssidsta));
+    strncpy(_wifi_passwordsta,  kDEFAULT_PASSWORD,  sizeof(_wifi_passwordsta));
     _flash_left = ESP.getFreeSketchSpace();
 }
 

--- a/src/mavesp8266_vehicle.cpp
+++ b/src/mavesp8266_vehicle.cpp
@@ -145,9 +145,9 @@ MavESP8266Vehicle::_readMessage()
                 }
 
                 //-- Check for message we might be interested
-                if(getWorld()->getComponent()->handleMessage(this, _message)){
+                if(getWorld()->getComponent()->handleMessage(this, &_message[_queue_count])){
                     //-- Eat message (don't send it to GCS)
-                    memset(&_message, 0, sizeof(_message));
+                    memset(&_message[_queue_count], 0, sizeof(mavlink_message_t));
                     msgReceived = false;
                     continue;
                 }

--- a/src/mavesp8266_vehicle.cpp
+++ b/src/mavesp8266_vehicle.cpp
@@ -38,6 +38,7 @@
 #include "mavesp8266.h"
 #include "mavesp8266_vehicle.h"
 #include "mavesp8266_parameters.h"
+#include "mavesp8266_component.h"
 
 //---------------------------------------------------------------------------------
 MavESP8266Vehicle::MavESP8266Vehicle()
@@ -142,6 +143,15 @@ MavESP8266Vehicle::_readMessage()
                         _last_heartbeat = millis();
                     _checkLinkErrors(&_message[_queue_count]);
                 }
+
+                //-- Check for message we might be interested
+                if(getWorld()->getComponent()->handleMessage(this, _message)){
+                    //-- Eat message (don't send it to GCS)
+                    memset(&_message, 0, sizeof(_message));
+                    msgReceived = false;
+                    continue;
+                }
+
                 break;
             }
         }


### PR DESCRIPTION
- The COMP_ID_UDP_BRIDGE message handling is moved from the GCS class to it's own file. Should be cleaner and easier to maintain. Also, these messages can now be handled coming from both the GCS and the Vehicle side
- In the HTTP API, the logger now returns the correct length (based on decoded string size) and the correct start position relative to the absolute start of the log at boot.
- Reset to Factory pin now triggered by a low signal on the GPIO02 pin. It is handled by an interrupt, so resetting should be possible while hanging in setup(). This has been verified to work.