### PR TITLE
UDP buffer management.

### DIFF
--- a/src/mavesp8266.cpp
+++ b/src/mavesp8266.cpp
@@ -46,6 +46,7 @@ MavESP8266Bridge::MavESP8266Bridge()
     , _component_id(0)
     , _seq_expected(0)
     , _last_heartbeat(0)
+    , _last_status_time(0)
     , _forwardTo(NULL)
 {
     memset(&_status, 0, sizeof(_status));
@@ -79,7 +80,6 @@ MavESP8266Bridge::_checkLinkErrors(mavlink_message_t* msg)
     _seq_expected = msg->seq + 1;
     _status.packets_lost += packet_lost_count;
 }
-
 
 //---------------------------------------------------------------------------------
 MavESP8266Log::MavESP8266Log()

--- a/src/mavesp8266.h
+++ b/src/mavesp8266.h
@@ -92,14 +92,15 @@ public:
     virtual ~MavESP8266Bridge(){;}
     virtual void    begin           (MavESP8266Bridge* forwardTo);
     virtual void    readMessage     () = 0;
-    virtual void    sendMessage     (mavlink_message_t* message, int count) = 0;
-    virtual void    sendMessage     (mavlink_message_t* message) = 0;
+    virtual int     sendMessage     (mavlink_message_t* message, int count) = 0;
+    virtual int     sendMessage     (mavlink_message_t* message) = 0;
     virtual bool    heardFrom       () { return _heard_from;    }
     virtual uint8_t systemID        () { return _system_id;     }
     virtual uint8_t componentID     () { return _component_id;  }
     virtual linkStatus* getStatus   () { return &_status;       }
 protected:
     virtual void    _checkLinkErrors(mavlink_message_t* msg);
+    virtual void    _sendRadioStatus() = 0;
 protected:
     bool                    _heard_from;
     uint8_t                 _system_id;
@@ -107,6 +108,7 @@ protected:
     uint8_t                 _seq_expected;
     uint32_t                _last_heartbeat;
     linkStatus              _status;
+    unsigned long           _last_status_time;
     MavESP8266Bridge*       _forwardTo;
 };
 

--- a/src/mavesp8266_gcs.h
+++ b/src/mavesp8266_gcs.h
@@ -46,12 +46,13 @@ public:
 
     void    begin                   (MavESP8266Bridge* forwardTo, IPAddress gcsIP);
     void    readMessage             ();
-    void    sendMessage             (mavlink_message_t* message, int count);
-    void    sendMessage             (mavlink_message_t* message);
+    int     sendMessage             (mavlink_message_t* message, int count);
+    int     sendMessage             (mavlink_message_t* message);
+protected:
+    void    _sendRadioStatus        ();
 
 private:
     bool    _readMessage            ();
-    void    _sendRadioStatus        ();
     void    _sendStatusMessage      (uint8_t type, const char* text);
     void    _handleParamSet         (mavlink_param_set_t* param);
     void    _handleParamRequestList ();

--- a/src/mavesp8266_httpd.cpp
+++ b/src/mavesp8266_httpd.cpp
@@ -301,7 +301,8 @@ void handle_getJSysStatus()
         "\"vpackets\": \"%u\", "
         "\"vsent\": \"%u\", "
         "\"vlost\": \"%u\", "
-        "\"radio\": \"%u\""
+        "\"radio\": \"%u\", "
+        "\"buffer\": \"%u\""
         " }",
         gcsStatus->packets_received,
         gcsStatus->packets_sent,
@@ -309,7 +310,8 @@ void handle_getJSysStatus()
         vehicleStatus->packets_received,
         vehicleStatus->packets_sent,
         vehicleStatus->packets_lost,
-        gcsStatus->radio_status_sent
+        gcsStatus->radio_status_sent,
+        vehicleStatus->queue_status
     );
     webServer.send(200, "application/json", message);
 }

--- a/src/mavesp8266_vehicle.cpp
+++ b/src/mavesp8266_vehicle.cpp
@@ -43,6 +43,7 @@
 MavESP8266Vehicle::MavESP8266Vehicle()
     : _queue_count(0)
     , _queue_time(0)
+    , _buffer_status(50.0)
 {
     memset(_message, 0 , sizeof(_message));
 }
@@ -68,30 +69,57 @@ MavESP8266Vehicle::begin(MavESP8266Bridge* forwardTo)
 void
 MavESP8266Vehicle::readMessage()
 {
-    if(_readMessage()) {
-        _queue_count++;
+    if(_queue_count < UAS_QUEUE_SIZE) {
+        if(_readMessage()) {
+            _queue_count++;
+        }
     }
     //-- Do we have a message to send and is it time to forward data?
-    if(_queue_count && (_queue_count == UAS_QUEUE_SIZE || (millis() - _queue_time) > UAS_QUEUE_TIMEOUT)) {
-        _forwardTo->sendMessage(_message, _queue_count);
-        memset(_message, 0, sizeof(_message));
-        _queue_count = 0;
-        _queue_time  = millis();
+    if(_queue_count && (_queue_count >= UAS_QUEUE_THRESHOLD || (millis() - _queue_time) > UAS_QUEUE_TIMEOUT)) {
+        int sent = _forwardTo->sendMessage(_message, _queue_count);
+        //-- Sent it all?
+        if(sent == _queue_count) {
+            memset(_message, 0, sizeof(_message));
+            _queue_count = 0;
+            _queue_time  = millis();
+        //-- Sent at least some?
+        } else if(sent) {
+            //-- Move the pending ones up the queue
+            int left = _queue_count - sent;
+            for(int i = 0; i < left; i++) {
+                memcpy(&_message[sent+i], &_message[i], sizeof(mavlink_message_t));
+            }
+            _queue_count = left;
+        }
+        //-- Maintain buffer status
+        float cur_status  = 0.0;
+        float buffer_size = (float)UAS_QUEUE_THRESHOLD;
+        float buffer_left = (float)(UAS_QUEUE_THRESHOLD - _queue_count);
+        if(buffer_left > 0.0)
+            cur_status = ((buffer_left / buffer_size) * 100.0f);
+        _buffer_status = (_buffer_status * 0.05f) + (cur_status * 0.95);
+    }
+    //-- Update radio status (1Hz)
+    if(_heard_from && (millis() - _last_status_time > 1000)) {
+        delay(0);
+        _sendRadioStatus();
+        _last_status_time = millis();
     }
 }
 
 //---------------------------------------------------------------------------------
 //-- Send MavLink message to UAS
-void
+int
 MavESP8266Vehicle::sendMessage(mavlink_message_t* message, int count) {
     for(int i = 0; i < count; i++) {
         sendMessage(&message[i]);
     }
+    return count;
 }
 
 //---------------------------------------------------------------------------------
 //-- Send MavLink message to UAS
-void
+int
 MavESP8266Vehicle::sendMessage(mavlink_message_t* message) {
     // Translate message to buffer
     char buf[300];
@@ -99,16 +127,15 @@ MavESP8266Vehicle::sendMessage(mavlink_message_t* message) {
     // Send it
     Serial.write((uint8_t*)(void*)buf, len);
     _status.packets_sent++;
+    return 1;
 }
 
 //---------------------------------------------------------------------------------
-//-- We have some special status to compute when asked for
+//-- We have some special status to capture when asked for
 linkStatus*
 MavESP8266Vehicle::getStatus()
 {
-    float buffer_size = (float)UAS_QUEUE_SIZE;
-    float buffer_left = (float)(UAS_QUEUE_SIZE - _queue_count);
-    _status.queue_status = (uint8_t)((buffer_left / buffer_size) * 100.0f);
+    _status.queue_status = (uint8_t)_buffer_status;
     return &_status;
 }
 
@@ -153,4 +180,28 @@ MavESP8266Vehicle::_readMessage()
         }
     }
     return msgReceived;
+}
+
+//---------------------------------------------------------------------------------
+//-- Send Radio Status
+void
+MavESP8266Vehicle::_sendRadioStatus()
+{
+    getStatus();
+    //-- Build message
+    mavlink_message_t msg;
+    mavlink_msg_radio_status_pack(
+        _forwardTo->systemID(),
+        MAV_COMP_ID_UDP_BRIDGE,
+        &msg,
+        0xff,   // We don't have access to RSSI
+        0xff,   // We don't have access to Remote RSSI
+        _status.queue_status, // UDP queue status
+        0,      // We don't have access to noise data
+        0,      // We don't have access to remote noise data
+        (uint16_t)(_status.packets_lost / 10),
+        0       // We don't fix anything
+    );
+    sendMessage(&msg);
+    _status.radio_status_sent++;
 }

--- a/src/mavesp8266_vehicle.h
+++ b/src/mavesp8266_vehicle.h
@@ -41,7 +41,8 @@
 #include "mavesp8266.h"
 
 //-- UDP Outgoing Packet Queue
-#define UAS_QUEUE_SIZE          2
+#define UAS_QUEUE_SIZE          60
+#define UAS_QUEUE_THRESHOLD     20
 #define UAS_QUEUE_TIMEOUT       5 // 5ms
 
 class MavESP8266Vehicle : public MavESP8266Bridge {
@@ -50,9 +51,12 @@ public:
 
     void    begin           (MavESP8266Bridge* forwardTo);
     void    readMessage     ();
-    void    sendMessage     (mavlink_message_t* message, int count);
-    void    sendMessage     (mavlink_message_t* message);
+    int     sendMessage     (mavlink_message_t* message, int count);
+    int     sendMessage     (mavlink_message_t* message);
     linkStatus* getStatus   ();
+
+protected:
+    void    _sendRadioStatus();
 
 private:
     bool    _readMessage    ();
@@ -60,6 +64,7 @@ private:
 private:
     int                     _queue_count;
     unsigned long           _queue_time;
+    float                   _buffer_status;
     mavlink_message_t       _message[UAS_QUEUE_SIZE];
 };
 


### PR DESCRIPTION
This is a first step at handling the high data loss on the UDP link.

The low level UDP stack now properly reports how many bytes were actually written to its TX buffer. Before these changes, there was no indication of buffer overflow and packets would simply go into the bit bucket once the buffers were full. With that information, and the use of much larger FIFO buffers, the data loss has been greatly minimized. Ideally, it would be great if we had access to the TX buffer status *before* sending any data but this is better than nothing.

For now, when the code notices the buffer is full (after a failed write), it waits a bit and tries again (once) to send the remaining data within that one message. I can't wait around long otherwise we start losing data on the UART link and the existing code can't handle a partially sent MavLink message. It then bails out and stops trying to send the remaining messages until the next loop cycle.

With these changes, I brought the drop count down from around 20% under high stress to less than 1%.

I've put an issue requesting access to the buffer status (https://github.com/esp8266/Arduino/issues/1988).
