### PR TITLE
Adding RSSI when in STA mode.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -164,6 +164,7 @@ void setup() {
         }
         if(WiFi.status() == WL_CONNECTED) {
             localIP = WiFi.localIP();
+            WiFi.setAutoReconnect(true);
         } else {
             //-- Fall back to AP mode if no connection could be established
             WiFi.disconnect(true);

--- a/src/mavesp8266.h
+++ b/src/mavesp8266.h
@@ -63,7 +63,7 @@ class MavESP8266GCS;
 //-- TODO: This needs to come from the build system
 #define MAVESP8266_VERSION_MAJOR    1
 #define MAVESP8266_VERSION_MINOR    0
-#define MAVESP8266_VERSION_BUILD    10
+#define MAVESP8266_VERSION_BUILD    11
 #define MAVESP8266_VERSION          ((MAVESP8266_VERSION_MAJOR << 24) & 0xFF00000) | ((MAVESP8266_VERSION_MINOR << 16) & 0x00FF0000) | (MAVESP8266_VERSION_BUILD & 0xFFFF)
 
 //-- Debug sent out to Serial1 (GPIO02), which is TX only (no RX).

--- a/src/mavesp8266_vehicle.cpp
+++ b/src/mavesp8266_vehicle.cpp
@@ -204,8 +204,8 @@ MavESP8266Vehicle::_sendRadioStatus()
         _forwardTo->systemID(),
         MAV_COMP_ID_UDP_BRIDGE,
         &msg,
-        0xff,   // We don't have access to RSSI
-        0xff,   // We don't have access to Remote RSSI
+        0,      // We don't have access to RSSI
+        0,      // We don't have access to Remote RSSI
         _status.queue_status, // UDP queue status
         0,      // We don't have access to noise data
         0,      // We don't have access to remote noise data


### PR DESCRIPTION
When in Station mode, we have access to RSSI (local). As that's the case, I am now adding the RSSI value to the Radio Status messages sent to the GCS.

While at it, looking through the Espressif SDK, I found a function:

`bool wifi_station_set_reconnect_policy(bool set)`

That's supposed to tell the ESP to automatically reconnect to the AP (when in Station Mode) if it gets disconnected. I could not find what the default state is nor anywhere in the (low level) code where this is set. The function is even exposed by the upper level API:

`bool ESP8266WiFiSTAClass::setAutoReconnect(bool autoReconnect)`

I am now setting this to true when the ESP is started in Station mode.