### PR TITLE
update mavlink submodule

### DIFF
--- a/src/mavesp8266.h
+++ b/src/mavesp8266.h
@@ -63,7 +63,7 @@ class MavESP8266GCS;
 //-- TODO: This needs to come from the build system
 #define MAVESP8266_VERSION_MAJOR    1
 #define MAVESP8266_VERSION_MINOR    0
-#define MAVESP8266_VERSION_BUILD    11
+#define MAVESP8266_VERSION_BUILD    12
 #define MAVESP8266_VERSION          ((MAVESP8266_VERSION_MAJOR << 24) & 0xFF00000) | ((MAVESP8266_VERSION_MINOR << 16) & 0x00FF0000) | (MAVESP8266_VERSION_BUILD & 0xFFFF)
 
 //-- Debug sent out to Serial1 (GPIO02), which is TX only (no RX).


### PR DESCRIPTION
This is necessary, so newer mavlink messages are correctly forwarded (like GPS_RTCM_DATA).

FYI @LorenzMeier