### PR TITLE
Remove AP DHCPC wait

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -178,15 +178,6 @@ void setup() {
         WiFi.encryptionType(AUTH_WPA2_PSK);
         WiFi.softAP(Parameters.getWifiSsid(), Parameters.getWifiPassword(), Parameters.getWifiChannel());
         localIP = WiFi.softAPIP();
-        DEBUG_LOG("Waiting for DHCPD...\n");
-        dhcp_status dstat = wifi_station_dhcpc_status();
-        while (dstat != DHCP_STARTED) {
-            #ifdef ENABLE_DEBUG
-            Serial1.print(".");
-            #endif
-            delay(500);
-            dstat = wifi_station_dhcpc_status();
-        }
         wait_for_client();
     }
 


### PR DESCRIPTION
I noticed this when using a static IP in STA mode with bad parameters: the AP fallback mode would hang as the static IP code turns off the DHCP client.

I'm not sure if this code is necessary. Currently it checks for the status of the DHCP **client** (wifi_station_dhcpc_status) when in AP mode. WiFi.softAP(..) already internally checks the status of the DHCP **server** with wifi_softap_dhcps_status.