### PR TITLE
Added "raw" mode (transparent serial bridge)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -208,9 +208,16 @@ void setup() {
 //-- Main Loop
 void loop() {
     if(!updateStatus.isUpdating()) {
-        GCS.readMessage();
-        delay(0);
-        Vehicle.readMessage();
+        if (Component.inRawMode()) {
+            GCS.readMessageRaw();
+            delay(0);
+            Vehicle.readMessageRaw();
+
+        } else {
+            GCS.readMessage();
+            delay(0);
+            Vehicle.readMessage();
+        }
     }
     updateServer.checkUpdates();
 }

--- a/src/mavesp8266.h
+++ b/src/mavesp8266.h
@@ -93,8 +93,10 @@ public:
     virtual ~MavESP8266Bridge(){;}
     virtual void    begin           (MavESP8266Bridge* forwardTo);
     virtual void    readMessage     () = 0;
+    virtual void    readMessageRaw  () = 0;
     virtual int     sendMessage     (mavlink_message_t* message, int count) = 0;
     virtual int     sendMessage     (mavlink_message_t* message) = 0;
+    virtual int     sendMessagRaw   (uint8_t *buffer, int len) = 0;
     virtual bool    heardFrom       () { return _heard_from;    }
     virtual uint8_t systemID        () { return _system_id;     }
     virtual uint8_t componentID     () { return _component_id;  }

--- a/src/mavesp8266_component.cpp
+++ b/src/mavesp8266_component.cpp
@@ -91,14 +91,6 @@ MavESP8266Component::handleMessage(MavESP8266Bridge* sender, mavlink_message_t* 
               return true;
           }
       }
-
-      // recognize FC reboot command and switch to raw mode for bootloader protocol to work
-      if(cmd.target_component == MAV_COMP_ID_ALL
-        && cmd.command == MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN) {
-        getWorld()->getLogger()->log("Raw mode enabled (cmd %d %d)\n", cmd.command, cmd.target_component);
-        _in_raw_mode = true;
-        _in_raw_mode_time = 0;
-      }
   //-----------------------------------------------
   //-- MAVLINK_MSG_ID_PARAM_REQUEST_LIST
   } else if(message->msgid == MAVLINK_MSG_ID_PARAM_REQUEST_LIST) {
@@ -286,6 +278,13 @@ MavESP8266Component::_handleCmdLong(MavESP8266Bridge* sender, mavlink_command_lo
         if((uint8_t)cmd->param2 == 1) {
             result = MAV_RESULT_ACCEPTED;
             reboot = true;
+        }
+
+        // recognize FC reboot command and switch to raw mode for bootloader protocol to work
+        if(compID == MAV_COMP_ID_ALL && (uint8_t)cmd->param1 > 0) {
+          getWorld()->getLogger()->log("Raw mode enabled (cmd %d %d)\n", cmd->command, compID);
+          _in_raw_mode = true;
+          _in_raw_mode_time = 0;
         }
     }
     //-- Response

--- a/src/mavesp8266_component.h
+++ b/src/mavesp8266_component.h
@@ -46,6 +46,8 @@ public:
 
     //- Returns true if the component consumed the message
     bool handleMessage        (MavESP8266Bridge* sender, mavlink_message_t* message);
+    bool inRawMode            ();
+    void resetRawMode         () {_in_raw_mode_time = millis();}
 
 private:
     void    _sendStatusMessage      (MavESP8266Bridge* sender, uint8_t type, const char* text);
@@ -58,6 +60,9 @@ private:
     void    _handleCmdLong          (MavESP8266Bridge* sender, mavlink_command_long_t* cmd, uint8_t compID);
 
     void    _wifiReboot             (MavESP8266Bridge* sender);
+
+    bool    _in_raw_mode;
+    unsigned long       _in_raw_mode_time;
 };
 
 #endif

--- a/src/mavesp8266_component.h
+++ b/src/mavesp8266_component.h
@@ -47,7 +47,7 @@ public:
     //- Returns true if the component consumed the message
     bool handleMessage        (MavESP8266Bridge* sender, mavlink_message_t* message);
     bool inRawMode            ();
-    void resetRawMode         () {_in_raw_mode_time = millis();}
+    void resetRawMode         () { _in_raw_mode_time = millis(); }
 
 private:
     void    _sendStatusMessage      (MavESP8266Bridge* sender, uint8_t type, const char* text);
@@ -61,8 +61,8 @@ private:
 
     void    _wifiReboot             (MavESP8266Bridge* sender);
 
-    bool    _in_raw_mode;
-    unsigned long       _in_raw_mode_time;
+    bool            _in_raw_mode;
+    unsigned long   _in_raw_mode_time;
 };
 
 #endif

--- a/src/mavesp8266_gcs.cpp
+++ b/src/mavesp8266_gcs.cpp
@@ -153,6 +153,33 @@ MavESP8266GCS::_readMessage()
     return msgReceived;
 }
 
+void
+MavESP8266GCS::readMessageRaw() {
+    int udp_count = _udp.parsePacket();
+    char buf[1024];
+    int buf_index = 0;
+
+    if(udp_count > 0)
+    {
+        while(buf_index < udp_count)
+        {
+            int result = _udp.read();
+            if (result >= 0)
+            {
+                buf[buf_index] = (char)result;
+                buf_index++;
+            }
+        }
+
+        if (buf[0] == 0x30 && buf[1] == 0x20) {
+            // reboot command, switch out of raw mode soon
+            getWorld()->getComponent()->resetRawMode();
+        }
+
+        _forwardTo->sendMessagRaw((uint8_t*)buf, buf_index);
+    }
+}
+
 //---------------------------------------------------------------------------------
 //-- Forward message(s) to the GCS
 int
@@ -189,6 +216,15 @@ int
 MavESP8266GCS::sendMessage(mavlink_message_t* message) {
     _sendSingleUdpMessage(message);
     return 1;
+}
+
+int
+MavESP8266GCS::sendMessagRaw(uint8_t *buffer, int len) {
+    _udp.beginPacket(_ip, _udp_port);
+    size_t sent = _udp.write(buffer, len);
+    _udp.endPacket();
+    //_udp.flush();
+    return sent;
 }
 
 //---------------------------------------------------------------------------------

--- a/src/mavesp8266_gcs.h
+++ b/src/mavesp8266_gcs.h
@@ -46,8 +46,10 @@ public:
 
     void    begin                   (MavESP8266Bridge* forwardTo, IPAddress gcsIP);
     void    readMessage             ();
+    void    readMessageRaw          ();
     int     sendMessage             (mavlink_message_t* message, int count);
     int     sendMessage             (mavlink_message_t* message);
+    int     sendMessagRaw           (uint8_t *buffer, int len);
 protected:
     void    _sendRadioStatus        ();
 

--- a/src/mavesp8266_vehicle.cpp
+++ b/src/mavesp8266_vehicle.cpp
@@ -108,6 +108,24 @@ MavESP8266Vehicle::readMessage()
     }
 }
 
+void
+MavESP8266Vehicle::readMessageRaw() {
+    char buf[1024];
+    int buf_index = 0;
+
+    while(Serial.available() && buf_index < 300)
+    {
+        int result = Serial.read();
+        if (result >= 0)
+        {
+            buf[buf_index] = (char)result;
+            buf_index++;
+        }
+    }
+
+    _forwardTo->sendMessagRaw((uint8_t*)buf, buf_index);
+}
+
 //---------------------------------------------------------------------------------
 //-- Send MavLink message to UAS
 int
@@ -129,6 +147,13 @@ MavESP8266Vehicle::sendMessage(mavlink_message_t* message) {
     Serial.write((uint8_t*)(void*)buf, len);
     _status.packets_sent++;
     return 1;
+}
+
+int
+MavESP8266Vehicle::sendMessagRaw(uint8_t *buffer, int len) {
+    Serial.write(buffer, len);
+    //Serial.flush();
+    return len;
 }
 
 //---------------------------------------------------------------------------------

--- a/src/mavesp8266_vehicle.h
+++ b/src/mavesp8266_vehicle.h
@@ -51,8 +51,10 @@ public:
 
     void    begin           (MavESP8266Bridge* forwardTo);
     void    readMessage     ();
+    void    readMessageRaw  ();
     int     sendMessage     (mavlink_message_t* message, int count);
     int     sendMessage     (mavlink_message_t* message);
+    int     sendMessagRaw   (uint8_t *buffer, int len);
     linkStatus* getStatus   ();
 
 protected:


### PR DESCRIPTION
This is adds a raw mode that can be used for FC firmware updates. I pushed this in case it's useful, however I will pursue another approach for OTA updates now: HTTP upload and bootloading via mavesp, which I believe makes more sense from an interface point of view and keeps the bootloading protocol simple.
Reference: https://github.com/PX4/Bootloader/issues/48