### PR TITLE
add neopixel status; fix baud=0 issue; improve debug output

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,13 @@ The MavESP8266 handles its own set of parameters and commands. Look at the [PARA
 ### HTTP Protocol
 
 There are some preliminary URLs that can be used for checking the WiFi Bridge status as well as updating firmware and changing parameters. [You can find it here.](HTTP.md)
+
+### Neopixel status LED
+
+A Neopixel (WS2812) can be connected to GPIO12 when using an esp12. The LED shows the current
+system status as follows:
+- red: resetting
+- orange: attempting to connect as STA
+- pink: waiting for Wifi client as AP
+- blue: broadcasting mavlink (no GCS heard from)
+- green: unicasting mavlink (GCS heard from)

--- a/esp_extra.py
+++ b/esp_extra.py
@@ -5,7 +5,7 @@ env = DefaultEnvironment()
 env.Replace(
     MYUPLOADERFLAGS=[
         "-vv",
-        "-cd", "nodemcu",
+        "-cd", "$UPLOAD_RESETMETHOD",
         "-cb", "$UPLOAD_SPEED",
         "-cp", "$UPLOAD_PORT",
         "-ca", "0x00000",

--- a/platformio.ini
+++ b/platformio.ini
@@ -26,19 +26,19 @@ framework = arduino
 board = esp12e
 upload_speed = 921600
 #upload_port = /dev/tty.SLAB_USBtoUART
-build_flags = -Wl,-Tesp8266.flash.4m.ld
-extra_script = esp_extra.py
+build_flags = -Wl,-Tesp8266.flash.4m.ld -DENABLE_DEBUG
+extra_scripts = esp_extra.py
 
 [env:esp01_1m]
 platform = espressif8266
 framework = arduino
 board = esp01_1m
 upload_speed = 921600
-extra_script = esp_extra.py
+extra_scripts = esp_extra.py
 
 [env:esp01]
 platform = espressif8266
 framework = arduino
 board = esp01
 upload_speed = 921600
-extra_script = esp_extra.py
+extra_scripts = esp_extra.py

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,6 +43,7 @@
 #include "mavesp8266_component.h"
 
 #include <ESP8266mDNS.h>
+#include <Adafruit_NeoPixel.h>
 
 #define GPIO02  2
 
@@ -83,6 +84,7 @@ MavESP8266Vehicle       Vehicle;
 MavESP8266Httpd         updateServer;
 MavESP8266UpdateImp     updateStatus;
 MavESP8266Log           Logger;
+Adafruit_NeoPixel       Pixel = Adafruit_NeoPixel(1, 12, NEO_GRB + NEO_KHZ800);
 
 //---------------------------------------------------------------------------------
 //-- Accessors
@@ -100,6 +102,13 @@ MavESP8266WorldImp      World;
 MavESP8266World* getWorld()
 {
     return &World;
+}
+
+//---------------------------------------------------------------------------------
+//-- Set the color of the indicator RGB LED
+void set_pixel(int r, int g, int b) {
+    Pixel.setPixelColor(0, Pixel.Color(r/4,g/4,b/4));
+    Pixel.show();
 }
 
 //---------------------------------------------------------------------------------
@@ -139,23 +148,28 @@ void setup() {
     //   We only use it for non debug because GPIO02 is used as a serial
     //   pin (TX) when debugging.
     Serial1.begin(115200);
+    uart_set_debug(UART1);
 #else
     //-- Initialized GPIO02 (Used for "Reset To Factory")
     pinMode(GPIO02, INPUT_PULLUP);
     attachInterrupt(GPIO02, reset_interrupt, FALLING);
 #endif
     Logger.begin(2048);
+    Pixel.begin();
+    set_pixel(255, 0, 0); // red
 
-    DEBUG_LOG("\nConfiguring access point...\n");
     DEBUG_LOG("Free Sketch Space: %u\n", ESP.getFreeSketchSpace());
 
     WiFi.disconnect(true);
+    DEBUG_LOG("Configuring Wifi mode=%d...\n", Parameters.getWifiMode());
 
     if(Parameters.getWifiMode() == WIFI_MODE_STA){
         //-- Connect to an existing network
+        set_pixel(255, 196, 18); // orange
         WiFi.mode(WIFI_STA);
         WiFi.config(Parameters.getWifiStaIP(), Parameters.getWifiStaGateway(), Parameters.getWifiStaSubnet(), 0U, 0U);
         WiFi.begin(Parameters.getWifiStaSsid(), Parameters.getWifiStaPassword());
+        DEBUG_LOG("STA connecting to %s (%s)...\n", Parameters.getWifiStaSsid(), Parameters.getWifiStaPassword());
 
         //-- Wait a minute to connect
         for(int i = 0; i < 120 && WiFi.status() != WL_CONNECTED; i++) {
@@ -166,9 +180,11 @@ void setup() {
         }
         if(WiFi.status() == WL_CONNECTED) {
             localIP = WiFi.localIP();
+            DEBUG_LOG("Local IP: %s\n", localIP.toString().c_str());
             WiFi.setAutoReconnect(true);
         } else {
             //-- Fall back to AP mode if no connection could be established
+            DEBUG_LOG("Falling back to AP\n");
             WiFi.disconnect(true);
             Parameters.setWifiMode(WIFI_MODE_AP);
         }
@@ -176,6 +192,8 @@ void setup() {
 
     if(Parameters.getWifiMode() == WIFI_MODE_AP){
         //-- Start AP
+        set_pixel(212, 66, 244); // pink
+        DEBUG_LOG("AP using SSID %s...\n", Parameters.getWifiSsid());
         WiFi.mode(WIFI_AP);
         WiFi.encryptionType(AUTH_WPA2_PSK);
         WiFi.softAP(Parameters.getWifiSsid(), Parameters.getWifiPassword(), Parameters.getWifiChannel());
@@ -202,6 +220,7 @@ void setup() {
     Vehicle.begin((MavESP8266Bridge*)&GCS);
     //-- Initialize Update Server
     updateServer.begin(&updateStatus);
+    DEBUG_LOG("Ready\n"); delay(100);
 }
 
 //---------------------------------------------------------------------------------
@@ -220,4 +239,6 @@ void loop() {
         }
     }
     updateServer.checkUpdates();
+
+    if (GCS.heardFrom()) set_pixel(0,255,0); else set_pixel(98, 244, 252);
 }

--- a/src/mavesp8266.cpp
+++ b/src/mavesp8266.cpp
@@ -107,7 +107,10 @@ MavESP8266Log::log(const char *format, ...) {
     char temp[1024];
     size_t len = ets_vsnprintf(temp, 1024, format, arg);
 #ifdef ENABLE_DEBUG
-    Serial1.print(temp);
+    for(int i = 0; i < len; i++) {
+        if (temp[i] == '\n') Serial1.print('\r');
+        Serial1.print(temp[i]);
+    }
 #endif
 
     if(_buffer) {

--- a/src/mavesp8266_httpd.cpp
+++ b/src/mavesp8266_httpd.cpp
@@ -180,7 +180,7 @@ void handle_getParameters()
     String message = FPSTR(kHEADER);
     message += "<p>Parameters</p><table><tr><td width=\"240\">Name</td><td>Value</td></tr>";
     for(int i = 0; i < MavESP8266Parameters::ID_COUNT; i++) {
-        message += "<tr><td>";
+        message += "\n<tr><td>";
         message += getWorld()->getParameters()->getAt(i)->id;
         message += "</td>";
         unsigned long val = 0;

--- a/src/mavesp8266_vehicle.cpp
+++ b/src/mavesp8266_vehicle.cpp
@@ -56,7 +56,10 @@ MavESP8266Vehicle::begin(MavESP8266Bridge* forwardTo)
 {
     MavESP8266Bridge::begin(forwardTo);
     //-- Start UART connected to UAS
-    Serial.begin(getWorld()->getParameters()->getUartBaudRate());
+    int baud = getWorld()->getParameters()->getUartBaudRate();
+    if (baud == 0) baud = 921600;
+    DEBUG_LOG("Serial.begin %d\n", baud); delay(10);
+    Serial.begin(baud);
     //-- Swap to TXD2/RXD2 (GPIO015/GPIO013) For ESP12 Only
 #ifdef ENABLE_DEBUG
 #ifdef ARDUINO_ESP8266_ESP12


### PR DESCRIPTION
This PR has a number of fixes / improvements. I don't really expect it to be mergeable as-is and would appreciate what is desirable and what isn't.

On my esp8266 board I added a neopixel to show the status of the link using colors. Pretty simple and useful, but obviously not everyone has or wants that. Code could be wrapped in a #define or could add a config param.

I added a fix for the issue mentioned at the end of #47, which is that if the baud rate ends up being set to 0 the sketch crashes.

I added additional debug output, added CR for the LF-terminated lines, and enabled the Espressif SDK debug output. I find that when things don't work the more info I get the better. It doesn't spew stuff during normal operation, so I don't think it has any effect on performance.