### PR TITLE
Fix build with platformio 4.1.0

### DIFF
--- a/src/mavesp8266_httpd.cpp
+++ b/src/mavesp8266_httpd.cpp
@@ -35,13 +35,13 @@
  * @author Gus Grubba <mavlink@grubba.com>
  */
 
+#include <ESP8266WebServer.h>
+
 #include "mavesp8266.h"
 #include "mavesp8266_httpd.h"
 #include "mavesp8266_parameters.h"
 #include "mavesp8266_gcs.h"
 #include "mavesp8266_vehicle.h"
-
-#include <ESP8266WebServer.h>
 
 const char PROGMEM kTEXTPLAIN[]  = "text/plain";
 const char PROGMEM kTEXTHTML[]   = "text/html";


### PR DESCRIPTION
'F' ESP8266 macro (defined in cores/esp8266/WString.h) is undefined in  mavesp8266.h to prevent conflict with lib/mavlink/mavlink_sha256.h.
It is needed in ESP8266WebServer-impl.h that gets included from ESP8266WebServer.h.
Reordering those fixes the build, the proper fix would be to rename 'F' in MAVLink subproject.