### PR TITLE
Add workaround to build on VS/Pio (Windows)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -29,8 +29,11 @@ version_flags = "-DMAVESP8266_VERSION_MINOR="${version.minor} "-DMAVESP8266_VERS
 [env]
 platform = espressif8266@1.8.0
 framework = arduino
-build_flags = !echo "-DPIO_SRC_REV="$(git rev-parse HEAD) "-DPIO_BUILD_DATE="$(date +%%Y-%%m-%%d) "-DPIO_BUILD_TIME="$(date +%%H:%%M:%%S) ${version_env.version_flags}
+build_flags = ${version_env.version_flags}
 extra_scripts = pre:platformio_prebuild.py
+monitor_speed = 115200
+# monitor_flags = --raw
+# monitor_filters = colorize
 
 # Platform specific settings
 

--- a/platformio_prebuild.py
+++ b/platformio_prebuild.py
@@ -1,9 +1,26 @@
+import datetime
+import subprocess
+
 Import("env")
+
+# get revivion from Git
+revision = (
+    subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
+    .strip()
+    .decode("utf-8")
+)
+#get current date and time
+curr_date = datetime.datetime.now()
+date_str = f"{curr_date.year}-{curr_date.month:02}-{curr_date.day:02}"
+time_str = f"{curr_date.hour:02}:{curr_date.minute:02}:{curr_date.second:02}"
+
+# add revision and date/time as build informations to the existing build flags (workaround to fix compilation issue with "date +%%..." )
+build_flags = env['BUILD_FLAGS']
+build_flags[0] = "!echo" + ' "-DPIO_SRC_REV="' +  str(revision)  + ' "-DPIO_BUILD_DATE="' + date_str + ' "-DPIO_BUILD_TIME="' +  time_str + " " + build_flags[0]
 
 # retrieve build flags
 my_flags = env.ParseFlags(env['BUILD_FLAGS'])
 defines = {k: v for (k, v) in my_flags.get("CPPDEFINES")}
-
 version_string = defines.get("VERSION_STRING")  # e.g. "1.2.2"
 board_name = env["BOARD"]  # e.g. "esp01m"
 


### PR DESCRIPTION
Only to enable build on VS/Pio (Windows) because the "date( +%%Y.." not work on this context.

My solution consist in move a part of CPPDEFINE of the platformio.ini file into prebuild python script.
That work for all build context because python is cross platform but I cannot confirm by testing  because I don't have others kind of systems. 
(Don't hesitate to tell me if it's ok or not in these others systems)

I hope that will be helpfull...
